### PR TITLE
set HostConfig.{Dns,DnsSearch} to empty array if running in host mode

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -28,11 +28,19 @@ function DNS(core){
             self.bridge_interface = _.trim(stdout);
 
             self.core.scheduler.follower.container.set_start_arguments("docker", "HostConfig.Dns", function(options){
-                return JSON.stringify([self.bridge_interface]);
+                if(options.network_mode == "host")
+                    return JSON.stringify([]);
+                else
+                    return JSON.stringify([self.bridge_interface]);
             });
 
             self.get_tld(function(err, tld){
-                self.core.scheduler.follower.container.set_start_arguments("docker", "HostConfig.DnsSearch", JSON.stringify([tld]));
+                self.core.scheduler.follower.container.set_start_arguments("docker", "HostConfig.DnsSearch", function(options){
+                    if(options.network_mode == "host")
+                        return JSON.stringify([]);
+                    else
+                        return JSON.stringify([tld]);
+                });
             });
         });
     }, 2000);


### PR DESCRIPTION
Docker 1.9.0 chokes when specifying Dns & running in host networking mode